### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python2
 
+from __future__ import print_function
 import random
 import socket
 import pickle
@@ -43,7 +44,7 @@ class Client():
     def x(self, addr, length=0x100):
         self.fh.memcpy(data_base, addr, length)
         data = self.mem[0:length]
-        print hexdump(data, start=addr)
+        print(hexdump(data, start=addr))
 
     def r(self, addr, length=1):
         self.fh.memcpy(data_base, addr, length)
@@ -128,9 +129,9 @@ class Client():
         data = self.execute(rop)
         buf_base = u64(data, 0) - 0x10000
 
-        print "Static memory: 0x{:x} (You can use it between different calls)".format(buf_base)
-        print "Main binary base: 0x{:x}".format(u64(data, 8))
-        print "Webkit base: 0x{:x}".format(u64(data, 0x10))
+        print("Static memory: 0x{:x} (You can use it between different calls)".format(buf_base))
+        print("Main binary base: 0x{:x}".format(u64(data, 8)))
+        print("Webkit base: 0x{:x}".format(u64(data, 0x10)))
 
     def get_bases(self):
         rop = Rop()
@@ -154,7 +155,7 @@ class Client():
                 base += chunk
                 sent += chunk
 
-                print "{:.2f}%".format(100.0 * sent / whole)
+                print("{:.2f}%".format(100.0 * sent / whole))
 
                 fout.write(data)
 
@@ -205,15 +206,15 @@ class Client():
             attr_str += 'UNCACHED '
 
         if state != 0:
-            print '[%s] 0x%010x-0x%010x size=0x%010x [%s] %s' % (perm_str, base, base+size-1, size, type_map[state], attr_str)
+            print('[%s] 0x%010x-0x%010x size=0x%010x [%s] %s' % (perm_str, base, base+size-1, size, type_map[state], attr_str))
             if unk1 != 0:
-                print '  !!Unk1!!:   0x%x' % unk1
+                print('  !!Unk1!!:   0x%x' % unk1)
             if unk2 != 0:
-                print '  Unk2:   0x%x' % unk2
+                print('  Unk2:   0x%x' % unk2)
             if unk3 != 0:
-                print '  !!Unk3!!:   0x%x' % unk3
+                print('  !!Unk3!!:   0x%x' % unk3)
             if pageinfo != 0:
-                print '  Info:   0x%x' % pageinfo
+                print('  Info:   0x%x' % pageinfo)
 
         return base + size
 
@@ -255,9 +256,9 @@ class Client():
         """ Download file `src` from switch to `dst` """
         fin = self.fh.fopen(src, "rb")
         if not fin:
-            print "failed to open '{}' for dump".format(src)
+            print("failed to open '{}' for dump".format(src))
             return
-        print 'fopen success'
+        print('fopen success')
         fout = open(dst, "wb")
         while True:
             ret = self.fh.fread(data_base, 1, RPC_RESPONSE_LEN - RPC_SCRATCH_SIZE, fin)
@@ -272,9 +273,9 @@ class Client():
         fin = open(src, "rb")
         fout = self.fh.fopen(dst, "wb")
         if not fout:
-            print "failed to open '{}' for write".format(dst)
+            print("failed to open '{}' for write".format(dst))
             return
-        print 'fopen success'
+        print('fopen success')
         while True:
             filedata = fin.read(0x1000)
             if len(filedata) == 0:
@@ -282,10 +283,10 @@ class Client():
             self.w_big(mem+0x2000, filedata)
             ret = self.fh.fwrite(mem+0x2000, 1, len(filedata), fout)
             if ret == 0:
-                print "File write failed."
+                print("File write failed.")
                 break
             if ret < len(filedata):
-                print "Only 0x%x of 0x%x bytes were written, aborting." % (ret, len(filedata))
+                print("Only 0x%x of 0x%x bytes were written, aborting." % (ret, len(filedata)))
                 break
         self.fh.fclose(fout)
         fin.close()
@@ -295,7 +296,7 @@ class Client():
             os.mkdir(host_path)
         ret = self.fh.OpenDirectory(data_base, path, 3)
         if ret != 0:
-            print "failed to open '{0}', error={1}=0x{1:x}".format(path, ret)
+            print("failed to open '{0}', error={1}=0x{1:x}".format(path, ret))
             return
         handle = u64(self.mem, 0)
         while True:
@@ -307,7 +308,7 @@ class Client():
             entry = self.mem[0x200:0x200 + 0x310]
             is_file = u32(entry, 0x304) & 1
             name = c_str(entry, 0)
-            print "{}{}{}".format(prefix, name, "/" if not is_file else "")
+            print("{}{}{}".format(prefix, name, "/" if not is_file else ""))
             fullpath = "{}/{}".format(path, name)
             if dump_files and is_file:
                 self.dump_file(fullpath, os.path.join(host_path, name))
@@ -407,21 +408,21 @@ class Client():
 
         self.w(mem+8, 'sm:\0')
         if self.svcConnectToPort(mem, mem+8) != 0:
-            print '[-] svcConnectToPort failed'
+            print('[-] svcConnectToPort failed')
             return
         srv_handle = c.r32(mem)
-        print '[+] Handle', srv_handle
+        print('[+] Handle', srv_handle)
         self.w32(self.r64(D.srv_objptr)+12, srv_handle)
-        print '[+] OK'
+        print('[+] OK')
 
     def srv_bruteforce(self, start=''):
         def test(fout, a,b='\0',c='\0',d='\0',e='\0',f='\0',g='\0',h='\0'):
             name_s = (a+b+c+d+e+f+g+h)
-            print 'testing %s' % name_s
+            print('testing %s' % name_s)
             name = ord(a) | ord(b)<<8 | ord(c)<<16 | ord(d)<<24 | ord(e)<<32 | ord(f)<<40 | ord(g)<<48 | ord(h)<<56
             ret = self.srv_cmd3(name)
             if ret != 3605:
-                print ret, name_s
+                print(ret, name_s)
                 fout.write("%s\n" % (name_s))
                 fout.flush()
 
@@ -448,7 +449,7 @@ class Client():
         ret = c.srv_cmd3(int(name[::-1].encode('hex'), 16))
         if ret == 3605:
             return '[*] NOT FOUND'
-        print ret
+        print(ret)
         return '[*] !!! FOUND !!! :D'
 
     def cmd(self, h, _id,
@@ -694,8 +695,8 @@ class Client():
 
 if __name__ == "__main__":
     import code
-    print '== Switch RPC Client =='
-    print ''
+    print('== Switch RPC Client ==')
+    print('')
     c = Client()
     __bases = c.get_bases()
     mem = __bases[0]

--- a/functionhelper.py
+++ b/functionhelper.py
@@ -4,6 +4,11 @@ from rop import F, G, Rop, data_base
 from rpc import RPC_RESPONSE_LEN
 from util import u64
 
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
+
 class FunctionHelper:
 
     def __init__(self, ch):
@@ -19,7 +24,7 @@ class FunctionHelper:
         return f
 
     def call(self, func, *args, **kwargs):
-        if type(func) in [str, unicode]:
+        if isinstance(func, (str, unicode)):
             if func in self.funcs:
                 func = self.funcs[func]
             else:

--- a/ipc.py
+++ b/ipc.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import struct
 
 class IpcCmd:
@@ -137,7 +138,7 @@ class IpcCmd:
 
         cmd = c.r(cmdbuf, size)
 
-        print '__ Raw: _____'
+        print('__ Raw: _____')
         c.x(cmdbuf, size)
 
         self.pid = None
@@ -154,27 +155,27 @@ class IpcCmd:
             num_handles_move = (handle_desc >> 5) & 0xF
             num_handles = num_handles_copy+num_handles_move
 
-            print '__ Handles: ___'
+            print('__ Handles: ___')
             for i in range(start, num_handles_copy + start):
                 handle = c.r32(cmdbuf+12+i*4)
-                print '  [Copied] Handle 0x%x' % handle
+                print('  [Copied] Handle 0x%x' % handle)
                 self.recv_handles.append(handle)
             for i in range(num_handles_copy + start, num_handles + start):
                 handle = c.r32(cmdbuf+12+i*4)
-                print '  [Moved] Handle 0x%x' % handle
+                print('  [Moved] Handle 0x%x' % handle)
                 self.recv_handles.append(handle)
 
         pos = cmd.find('SFCO')
         ret = None
 
         if pos != -1:
-            print '__ Return ___'
+            print('__ Return ___')
             ret = cmd[pos+8 : pos+8+4]
             if len(ret) > 0:
                 ret = struct.unpack('<I', ret)[0]
-                print '0x%x' % ret
+                print('0x%x' % ret)
             else:
-                print '(void)'
+                print('(void)')
         self.recv_ret = ret
 
         self.recv_raw = cmd[pos:]

--- a/rpc.py
+++ b/rpc.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import Queue as queue
 import socket
 
@@ -100,7 +101,7 @@ class Rpc:
         rop.call(F.send, self.sockfd, data_base, RPC_RESPONSE_LEN, 0)
 
         new_stack = self.buf + RPC_ROP_OFF + RPC_ROP_SIZE * self.cur_stack + RPC_ROP_LOCALS
-        print "Using stack: 0x{:x}".format(new_stack)
+        print("Using stack: 0x{:x}".format(new_stack))
         self.cur_stack = 1 - self.cur_stack
 
         # Get next payload

--- a/server.py
+++ b/server.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python2
 
+from __future__ import print_function
 from sys import argv
 import threading
 
@@ -15,15 +16,15 @@ ipc_port = 6971
 
 def main():
     if len(argv) != 2:
-        print "usage: ./server.py MY_IP_AS_VISIBLE_FROM_SWITCH"
+        print("usage: ./server.py MY_IP_AS_VISIBLE_FROM_SWITCH")
         return -1
     host = argv[1]
 
-    print "!! ipc is extremely insecure but it's only listening on 127.0.0.1 !!"
+    print("!! ipc is extremely insecure but it's only listening on 127.0.0.1 !!")
 
-    print "running webserver on http://{}:{}/".format(host, webserver_port)
-    print "running sockserver on {}:{}".format(host, socket_port)
-    print "running ipc server on 127.0.0.1:{}".format(ipc_port)
+    print("running webserver on http://{}:{}/".format(host, webserver_port))
+    print("running sockserver on {}:{}".format(host, socket_port))
+    print("running ipc server on 127.0.0.1:{}".format(ipc_port))
 
     rpc = Rpc(host, socket_port)
 

--- a/sockserver.py
+++ b/sockserver.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import socket
 
 from util import u64
@@ -10,15 +11,15 @@ def sockserver(host, port, rpc):
     s.listen(10)
 
     c, addr = s.accept()
-    print c, addr
+    print(c, addr)
     setup_buf = c.recv(0x1000, socket.MSG_WAITALL)
 
     data_base = u64(setup_buf, 0)
     main_base = u64(setup_buf, 8)
     wk_base = u64(setup_buf, 0x10)
     sockfd = u64(setup_buf, 0x100)
-    print "got data of len 0x{:x}".format(len(setup_buf))
-    print "data: 0x{:x} main: 0x{:x} wk: 0x{:x} sockfd: {}".format(data_base, main_base, wk_base, sockfd)
+    print("got data of len 0x{:x}".format(len(setup_buf)))
+    print("data: 0x{:x} main: 0x{:x} wk: 0x{:x} sockfd: {}".format(data_base, main_base, wk_base, sockfd))
 
     # NOTE: in this first payload, data_base is at +0x8000
     # See rpc.py for the buf layout
@@ -26,22 +27,22 @@ def sockserver(host, port, rpc):
     rpc.set_args(sockfd, buf)
     relocs = {1: buf + RPC_DYNAMIC_MEM_OFF, 2: main_base, 3: wk_base} # 1 = data_base = dynamic mem
 
-    print "--- setup complete ---"
-    print "you can run ./client.py now"
+    print("--- setup complete ---")
+    print("you can run ./client.py now")
 
     while True:
         rop = rpc.next_payload()
         binary = rop.generate_binary(relocs)
-        print "Sending rop len = 0x{:x}".format(len(binary))
+        print("Sending rop len = 0x{:x}".format(len(binary)))
         binary += "\x00" * (RPC_ROP_LEN - len(binary))
 
         ret = c.send(binary)
 
-        print "Sent 0x{:x}".format(ret)
+        print("Sent 0x{:x}".format(ret))
 
         data = c.recv(RPC_RESPONSE_LEN, socket.MSG_WAITALL)
 
         rpc.res_q.put(data)
 
         # print "Got data: {} len 0x{:x}".format(data, len(data))
-        print "Got data len 0x{:x}".format(len(data))
+        print("Got data len 0x{:x}".format(len(data)))

--- a/test.py
+++ b/test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python2
+from __future__ import print_function
 import unittest
 import shutil
 import os
@@ -131,7 +132,7 @@ class Test(unittest.TestCase):
 
 def main():
 	if len(argv) != 3:
-		print "Usage: ./test.py main.bin wk.bin"
+		print("Usage: ./test.py main.bin wk.bin")
 		return -1
 
 	global g_main_bin

--- a/util.py
+++ b/util.py
@@ -1,5 +1,10 @@
 import struct
 
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
+
 def u32(b, off=0):
 	return struct.unpack("<I", b[off:off+4])[0]
 
@@ -24,7 +29,7 @@ def c_str(b, off=0):
 	return out
 
 def isint(x):
-    return type(x) is int or type(x) is long
+    return isinstance(x, (int, long))
 
 def hexdump( src, length=16, sep='.', start=0 ):
 	'''


### PR DESCRIPTION
Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3.  There might be other changes required to complete a port to Python 3 but this PR is a minimal, safe first step.

Run: [futurize --stage1 -w **/*.py](http://python-future.org/futurize_cheatsheet.html)

    See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes